### PR TITLE
Migrate to Starcounter 3.1.0 and sync with the upstream

### DIFF
--- a/samples/Hooks/Hooks.csproj
+++ b/samples/Hooks/Hooks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Starcounter.Database" Version="3.0.1" />
+    <PackageReference Include="Starcounter.Database" Version="3.0.2" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
   </ItemGroup>
 

--- a/samples/Hooks/Hooks.csproj
+++ b/samples/Hooks/Hooks.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Starcounter.Database" Version="3.0.0" />
+    <PackageReference Include="Starcounter.Database" Version="3.0.1" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
   </ItemGroup>
 

--- a/samples/Hooks/Hooks.csproj
+++ b/samples/Hooks/Hooks.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Starcounter.Database" Version="3.0.2" />
+    <PackageReference Include="Starcounter.Database" Version="3.1.0" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
   </ItemGroup>
 

--- a/samples/NestedTransactions/NestedTransactions.csproj
+++ b/samples/NestedTransactions/NestedTransactions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Starcounter.Database" Version="3.0.1" />
+    <PackageReference Include="Starcounter.Database" Version="3.0.2" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
   </ItemGroup>
 

--- a/samples/NestedTransactions/NestedTransactions.csproj
+++ b/samples/NestedTransactions/NestedTransactions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Starcounter.Database" Version="3.0.0" />
+    <PackageReference Include="Starcounter.Database" Version="3.0.1" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
   </ItemGroup>
 

--- a/samples/NestedTransactions/NestedTransactions.csproj
+++ b/samples/NestedTransactions/NestedTransactions.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Starcounter.Database" Version="3.0.2" />
+    <PackageReference Include="Starcounter.Database" Version="3.1.0" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
   </ItemGroup>
 

--- a/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
+++ b/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
-    <PackageReference Include="Starcounter.Database.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Starcounter.Database.Abstractions" Version="3.0.1" />
   </ItemGroup>
   
 </Project>

--- a/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
+++ b/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
-    <PackageReference Include="Starcounter.Database.Abstractions" Version="3.0.1" />
+    <PackageReference Include="Starcounter.Database.Abstractions" Version="3.0.2" />
   </ItemGroup>
   
 </Project>

--- a/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
+++ b/src/Starcounter.Database.Extensions/Starcounter.Database.Extensions.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.2" />
-    <PackageReference Include="Starcounter.Database.Abstractions" Version="3.0.2" />
+    <PackageReference Include="Starcounter.Database.Abstractions" Version="3.1.0" />
   </ItemGroup>
   
 </Project>

--- a/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
-    <PackageReference Include="Starcounter.Database" Version="3.0.0" />
-    <PackageReference Include="Starcounter.Database.TestResources" Version="3.0.0" />
+    <PackageReference Include="Starcounter.Database" Version="3.0.1" />
+    <PackageReference Include="Starcounter.Database.TestResources" Version="3.0.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
-    <PackageReference Include="Starcounter.Database" Version="3.0.1" />
-    <PackageReference Include="Starcounter.Database.TestResources" Version="3.0.1" />
+    <PackageReference Include="Starcounter.Database" Version="3.0.2" />
+    <PackageReference Include="Starcounter.Database.TestResources" Version="3.0.2" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />

--- a/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
+++ b/test/Starcounter.Database.Extensions.IntegrationTests/Starcounter.Database.Extensions.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -9,8 +9,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Scrutor" Version="3.2.0" />
-    <PackageReference Include="Starcounter.Database" Version="3.0.2" />
-    <PackageReference Include="Starcounter.Database.TestResources" Version="3.0.2" />
+    <PackageReference Include="Starcounter.Database" Version="3.1.0-*" />
+    <PackageReference Include="Starcounter.Database.TestResources" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />


### PR DESCRIPTION
**Issue**: [StarCounter: Upgrade starcounter to latest version #7403](https://github.com/ModularManagement/PalmaDoc/issues/7403).

The pull request ups the Starcounter reference to `3.1.0`, removes the `<UseRidGraph>true</UseRidGraph>` workaround, and syncs with the upstream from the Starcounter organization.